### PR TITLE
auc, intermidiate pred, sgda, extended early stop added

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>libfm</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
-libFM with Early Stopping
+libFM with Updated Early Stopping and others
 =========================
 
 Changes:
 
-* Removed mcmc and sgda optimization methods
-* Added validation data as mandatory parameter
-* Implemented early stopping of fm model
-* Validation data is MANDATORY for this verions
-* Removed handling of Meta 
-* Removed regression task
+* Extended early stop updates learning rate (divide by 2) after each early stop activation. However early stop is deactivated if learn rate reaches lower than 1e-6. From then, iterations continues with lastly updated learn rate.
+
+* Intermediate predictions saving at any desired iteration.
+
+* SGDA added
+
+* AUC evaluate per iteration. If early stop is used, validation auc can be maximised. Earlier validation log loss was minimized. Now have 2 options.
+
+* Makefile in src is updated (std c++) to support lambda expressions in ranking function for auc computation.
+
 
 Additional parameters:
 * early stopping (bool) -- enabling early stopping
 * num iterations for early stopping (int) -- how many iterations till break
+* optimize_metric auc -- which metric to optimize on validation set by early stop (two allowed: logloss and auc, default: logloss). This option used only when early stop is used.
+* pred_iter_step -- set iteration step at which to save intermidiate predictions. E.g. if set to 10, then after every 10th iteration, predictions will be saved (output files will be generated with informative naming).
 
 
 Example
@@ -20,9 +26,9 @@ Example
 
 ``` bash
 <path-to-libfm>/bin/libFM -task c -train <path-to-train-data> -test <path-to-test-data>
--validation <path-to-validation-data> -dim '1,1,8' -early_stop 1 -num_stop 15 
--out <where-predictions-to-save> -verbosity 0 -iter 40 
--method sgd -learn_rate 0.001 -init_stdev 0.0003
+-validation <path-to-validation-data> -dim '1,1,8' -early_stop 1 -num_stop 15 -optimize_metric auc 
+-pred_iter_step iter_step -out <where-predictions-to-save> -verbosity 0 -iter 40 
+-method sgd  -learn_rate 0.001 -init_stdev 0.0003
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@ libFM with Updated Early Stopping and others
 
 Changes:
 
-* Extended early stop updates learning rate (divide by 2) after each early stop activation. However early stop is deactivated if learn rate reaches lower than 1e-6. From then, iterations continues with lastly updated learn rate.
+* Extended early stop updates learning rate (divide by 2) after each early stop activation. However early stop is deactivated if learn rate reaches lower than 1e-6. From then, iterations continue with lastly updated learn rate.
 
-* Intermediate predictions saving at any desired iteration.
+* Intermediate predictions to save at any desired iteration.
 
 * SGDA added.
 
-* Load model functionality added (useful for starting from previously saved model coefficients).
+* Load model functionality added (useful for starting from previously saved model coefficients, instead of randomely initializing parameters).
 
 * AUC evaluate per iteration. If early stop is used, validation auc can be maximised. Earlier validation log loss was minimized. Now have 2 options.
 
@@ -18,7 +18,7 @@ Changes:
 
 Additional parameters:
 
-* optimize_metric auc -- which metric to optimize on validation set by early stop (two allowed: logloss and auc, default: logloss). This option used only when early stop is used.
+* optimize_metric -- which metric to optimize on validation set by early stop (two allowed: logloss and auc, default: logloss). This option used only when early stop is used.
 
 * pred_iter_step -- set iteration step at which to save intermidiate predictions. E.g. if set to 10, then after every 10th iteration, predictions will be saved (output files will be generated with informative naming).
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Changes:
 
 * Intermediate predictions saving at any desired iteration.
 
-* SGDA added
+* SGDA added.
+
+* Load model functionality added (useful for starting from previously saved model coefficients).
 
 * AUC evaluate per iteration. If early stop is used, validation auc can be maximised. Earlier validation log loss was minimized. Now have 2 options.
 
@@ -15,10 +17,12 @@ Changes:
 
 
 Additional parameters:
-* early stopping (bool) -- enabling early stopping
-* num iterations for early stopping (int) -- how many iterations till break
+
 * optimize_metric auc -- which metric to optimize on validation set by early stop (two allowed: logloss and auc, default: logloss). This option used only when early stop is used.
+
 * pred_iter_step -- set iteration step at which to save intermidiate predictions. E.g. if set to 10, then after every 10th iteration, predictions will be saved (output files will be generated with informative naming).
+
+* load_model -- saved_model_path
 
 
 Example
@@ -28,7 +32,7 @@ Example
 <path-to-libfm>/bin/libFM -task c -train <path-to-train-data> -test <path-to-test-data>
 -validation <path-to-validation-data> -dim '1,1,8' -early_stop 1 -num_stop 15 -optimize_metric auc 
 -pred_iter_step iter_step -out <where-predictions-to-save> -verbosity 0 -iter 40 
--method sgd  -learn_rate 0.001 -init_stdev 0.0003
+-method sgd  -learn_rate 0.001 -init_stdev 0.0003 -load_model saved_model_path
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Example
 ``` bash
 <path-to-libfm>/bin/libFM -task c -train <path-to-train-data> -test <path-to-test-data>
 -validation <path-to-validation-data> -dim '1,1,8' -early_stop 1 -num_stop 15 -optimize_metric auc 
--pred_iter_step iter_step -out <where-predictions-to-save> -verbosity 0 -iter 40 
--method sgd  -learn_rate 0.001 -init_stdev 0.0003 -load_model saved_model_path
+-pred_iter_step 10 -out <where-predictions-to-save> -verbosity 0 -iter 100
+-method sgd  -learn_rate 0.001 -init_stdev 0.0003 -load_model <saved-model-path>
 ```
 
 

--- a/src/fm_core/fm_model.h
+++ b/src/fm_core/fm_model.h
@@ -62,6 +62,7 @@ class fm_model {
 		double predict(sparse_row<FM_FLOAT>& x);
 		double predict(sparse_row<FM_FLOAT>& x, DVector<double> &sum, DVector<double> &sum_sqr);
 		void saveModel(std::string model_file_path);
+		int loadModel(std::string model_file_path);
 	private:
 		void splitString(const std::string& s, char c, std::vector<std::string>& v);
 	
@@ -159,6 +160,43 @@ void fm_model::saveModel(std::string model_file_path){
 	}
 	out_model.close();
 }
+
+/*
+ * Read the FM model (all the parameters) from a file.
+ * If no valid conversion could be performed, the function std::atof returns zero (0.0).
+ */
+int fm_model::loadModel(std::string model_file_path) {
+  std::string line;
+  std::ifstream model_file (model_file_path.c_str());
+  if (model_file.is_open()){
+    if (k0) {
+      if(!std::getline(model_file,line)){return 0;} // "#global bias W0"
+      if(!std::getline(model_file,line)){return 0;}
+      w0 = std::atof(line.c_str());
+    }
+    if (k1) {
+      if(!std::getline(model_file,line)){return 0;} //"#unary interactions Wj"
+      for (uint i = 0; i<num_attribute; i++){
+        if(!std::getline(model_file,line)){return 0;}
+        w(i) = std::atof(line.c_str());
+      }
+    }
+    if(!std::getline(model_file,line)){return 0;}; // "#pairwise interactions Vj,f"
+    for (uint i = 0; i<num_attribute; i++){
+      if(!std::getline(model_file,line)){return 0;}
+      std::vector<std::string> v_str;
+      splitString(line, ' ', v_str);
+      if ((int)v_str.size() != num_factor){return 0;}
+      for (int f = 0; f < num_factor; f++) {
+        v(f,i) = std::atof(v_str[f].c_str());
+      }
+    }
+    model_file.close();
+  }
+  else{ return 0;}
+  return 1;
+}
+
 
 /*
  * Splits the string s around matches of the given character c, and stores the substrings in the vector v

--- a/src/libfm/Makefile
+++ b/src/libfm/Makefile
@@ -9,10 +9,10 @@ all: libFM transpose convert
 
 libFM: libfm.o
 	mkdir -p $(BIN_DIR)
-	g++ -O3 -Wall libfm.o -o $(BIN_DIR)libFM
+	g++ -std=c++11 -Wall libfm.o -o $(BIN_DIR)libFM
 
 %.o: %.cpp
-	g++ -O3 -Wall -c $< -o $@
+	g++ -std=c++11 -Wall -c $< -o $@
 
 clean:	clean_lib
 	mkdir -p $(BIN_DIR)
@@ -24,9 +24,8 @@ clean_lib:
 
 transpose: tools/transpose.o
 	mkdir -p $(BIN_DIR)
-	g++ -O3 tools/transpose.o -o $(BIN_DIR)transpose
+	g++ -std=c++11 tools/transpose.o -o $(BIN_DIR)transpose
 
 convert: tools/convert.o
 	mkdir -p $(BIN_DIR)
-	g++ -O3 tools/convert.o -o $(BIN_DIR)convert
-
+	g++ -std=c++11 tools/convert.o -o $(BIN_DIR)convert

--- a/src/libfm/src/fm_learn_sgd.h
+++ b/src/libfm/src/fm_learn_sgd.h
@@ -41,13 +41,15 @@ class fm_learn_sgd: public fm_learn {
 		DVector<double> learn_rates;		
 		bool early_stop;
 		int num_stop;
-		
+		std::string optimize_metric;
+		std::string pred_out;
+		int pred_iter_step;
 		virtual void init() {		
 			fm_learn::init();	
 			learn_rates.setSize(3);
 		}		
 
-		virtual void learn(Data& train, Data& test, Data& validation) { 
+		virtual void learn(Data& train, Data& test, Data& validation ) {
 			fm_learn::learn(train, test, validation);
 			std::cout << "learnrate=" << learn_rate << std::endl;
 			std::cout << "learnrates=" << learn_rates(0) << "," << learn_rates(1) << "," << learn_rates(2) << std::endl;
@@ -58,6 +60,7 @@ class fm_learn_sgd: public fm_learn {
 			}
 			std::cout.flush();
 		}
+
 
 		void SGD(sparse_row<DATA_FLOAT> &x, const double multiplier, DVector<double> &sum) {
 			fm_SGD(fm, learn_rate, x, multiplier, sum); 

--- a/src/libfm/src/fm_learn_sgd_element.h
+++ b/src/libfm/src/fm_learn_sgd_element.h
@@ -84,7 +84,7 @@ class fm_learn_sgd_element: public fm_learn_sgd {
 // 					}
 // 				}
 
-        //show original auc, gradient was used for minizing (1.0-auc), that is maximizing auc.
+        //Early stop option for maximizing validation AUC (earlier was only minimizing validation log loss)
         if (early_stop){
           if(optimize_metric == "auc"){
             std::cout << "#Iter=" << std::setw(3) << i << "\tTrain=" << (1.0-metric_train) << "\tTest=" << (1.0-metric_test) << "\tValidation=" << (1.0-metric_validation) << "\tLearnRate=" <<   fm_learn_sgd::learn_rate << std::endl;

--- a/src/libfm/src/fm_learn_sgd_element_adapt_reg.h
+++ b/src/libfm/src/fm_learn_sgd_element_adapt_reg.h
@@ -1,0 +1,354 @@
+// Copyright (C) 2011, 2012, 2013, 2014 Steffen Rendle
+// Contact:   srendle@libfm.org, http://www.libfm.org/
+//
+// This file is part of libFM.
+//
+// libFM is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// libFM is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with libFM.  If not, see <http://www.gnu.org/licenses/>.
+//
+//
+// fm_learn_sgd_element_adapt_reg.h: Stochastic Gradient Descent based learning
+// for classification and regression using adaptive shrinkage
+//
+// Based on the publication(s):
+// - Steffen Rendle (2012): Learning Recommender Systems with Adaptive
+//   Regularization, in Proceedings of the 5th ACM International Conference on
+//   Web Search and Data Mining (WSDM 2012), Seattle, USA.
+//
+// theta' = theta - alpha*(grad_theta + 2*lambda*theta)
+//        = theta(1-2*alpha*lambda) - alpha*grad_theta
+//
+// lambda^* = lambda - alpha*(grad_lambda)
+// with
+//  grad_lambdaw0 = (grad l(y(x),y)) * (-2 * alpha * w_0)
+//  grad_lambdawg = (grad l(y(x),y)) * (-2 * alpha * (\sum_{l \in group(g)} x_l * w_l))
+//  grad_lambdafg = (grad l(y(x),y)) * (-2 * alpha * (\sum_{l} x_l * v'_lf) * \sum_{l \in group(g)} x_l * v_lf) - \sum_{l \in group(g)} x^2_l * v_lf * v'_lf)
+
+#ifndef FM_LEARN_SGD_ELEMENT_ADAPT_REG_H_
+#define FM_LEARN_SGD_ELEMENT_ADAPT_REG_H_
+
+#include <sstream>
+#include "fm_learn_sgd.h"
+
+
+class fm_learn_sgd_element_adapt_reg: public fm_learn_sgd {
+	public:
+		// regularization parameter
+		double reg_0; // shrinking the bias towards the mean of the bias (which is the bias) is the same as no regularization.
+
+		DVector<double> reg_w;
+		DMatrix<double> reg_v;
+
+		double mean_w, var_w;
+		DVector<double> mean_v, var_v;
+
+		// for each parameter there is one gradient to store
+		DVector<double> grad_w;
+		DMatrix<double> grad_v;
+
+		Data* validation;
+
+		// local parameters in the lambda_update step
+		DVector<double> lambda_w_grad;
+		DVector<double> sum_f, sum_f_dash_f;
+
+
+		virtual void init() {
+			fm_learn_sgd::init();
+
+			reg_0 = 0;
+			reg_w.setSize(meta->num_attr_groups);
+			reg_v.setSize(meta->num_attr_groups, fm->num_factor);
+
+			mean_v.setSize(fm->num_factor);
+			var_v.setSize(fm->num_factor);
+
+			grad_w.setSize(fm->num_attribute);
+			grad_v.setSize(fm->num_factor, fm->num_attribute);
+
+			grad_w.init(0.0);
+			grad_v.init(0.0);
+
+			lambda_w_grad.setSize(meta->num_attr_groups);
+			sum_f.setSize(meta->num_attr_groups);
+			sum_f_dash_f.setSize(meta->num_attr_groups);
+
+
+			if (log != NULL) {
+				log->addField("logloss_train", std::numeric_limits<double>::quiet_NaN());
+				log->addField("logloss_val", std::numeric_limits<double>::quiet_NaN());
+
+				log->addField("wmean", std::numeric_limits<double>::quiet_NaN());
+				log->addField("wvar", std::numeric_limits<double>::quiet_NaN());
+				for (int f = 0; f < fm->num_factor; f++) {
+					{
+						std::ostringstream ss;
+						ss << "vmean" << f;
+						log->addField(ss.str(), std::numeric_limits<double>::quiet_NaN());
+					}
+					{
+						std::ostringstream ss;
+						ss << "vvar" << f;
+						log->addField(ss.str(), std::numeric_limits<double>::quiet_NaN());
+					}
+				}
+				for (uint g = 0; g < meta->num_attr_groups; g++) {
+					{
+						std::ostringstream ss;
+						ss << "regw[" << g << "]";
+						log->addField(ss.str(), std::numeric_limits<double>::quiet_NaN());
+					}
+					for (int f = 0; f < fm->num_factor; f++) {
+						{
+							std::ostringstream ss;
+							ss << "regv[" << g << "," << f << "]";
+							log->addField(ss.str(), std::numeric_limits<double>::quiet_NaN());
+						}
+					}
+				}
+			}
+		}
+
+
+		void sgd_theta_step(sparse_row<FM_FLOAT>& x, const DATA_FLOAT target) {
+			double p = fm->predict(x, sum, sum_sqr);
+			double mult = 0;
+			if (task == 0) {
+				p = std::min(max_target, p);
+				p = std::max(min_target, p);
+				mult = 2 * (p - target);
+			} else if (task == 1) {
+				mult = target * (  (1.0/(1.0+exp(-target*p))) - 1.0 );
+			}
+
+			// make the update with my regularization constants:
+			if (fm->k0) {
+				double& w0 = fm->w0;
+				double grad_0 = mult;
+				w0 -= learn_rate * (grad_0 + 2 * reg_0 * w0);
+			}
+			if (fm->k1) {
+				for (uint i = 0; i < x.size; i++) {
+					uint g = meta->attr_group(x.data[i].id);
+					double& w = fm->w(x.data[i].id);
+					grad_w(x.data[i].id) = mult * x.data[i].value;
+					w -= learn_rate * (grad_w(x.data[i].id) + 2 * reg_w(g) * w);
+				}
+			}
+			for (int f = 0; f < fm->num_factor; f++) {
+				for (uint i = 0; i < x.size; i++) {
+					uint g = meta->attr_group(x.data[i].id);
+					double& v = fm->v(f,x.data[i].id);
+					grad_v(f,x.data[i].id) = mult * (x.data[i].value * (sum(f) - v * x.data[i].value)); // grad_v_if = (y(x)-y) * [ x_i*(\sum_j x_j v_jf) - v_if*x^2 ]
+					v -= learn_rate * (grad_v(f,x.data[i].id) + 2 * reg_v(g,f) * v);
+				}
+			}
+		}
+
+		double predict_scaled(sparse_row<FM_FLOAT>& x) {
+			double p = 0.0;
+			if (fm->k0) {
+				p += fm->w0;
+			}
+			if (fm->k1) {
+				for (uint i = 0; i < x.size; i++) {
+					assert(x.data[i].id < fm->num_attribute);
+					uint g = meta->attr_group(x.data[i].id);
+					double& w = fm->w(x.data[i].id);
+					double w_dash = w - learn_rate * (grad_w(x.data[i].id) + 2 * reg_w(g) * w);
+					p += w_dash * x.data[i].value;
+				}
+			}
+			for (int f = 0; f < fm->num_factor; f++) {
+				sum(f) = 0.0;
+				sum_sqr(f) = 0.0;
+				for (uint i = 0; i < x.size; i++) {
+					uint g = meta->attr_group(x.data[i].id);
+					double& v = fm->v(f,x.data[i].id);
+					double v_dash = v - learn_rate * (grad_v(f,x.data[i].id) + 2 * reg_v(g,f) * v);
+					double d = v_dash * x.data[i].value;
+					sum(f) += d;
+					sum_sqr(f) += d*d;
+				}
+				p += 0.5 * (sum(f)*sum(f) - sum_sqr(f));
+			}
+			return p;
+		}
+
+		void sgd_lambda_step(sparse_row<FM_FLOAT>& x, const DATA_FLOAT target) {
+			double p = predict_scaled(x);
+			double grad_loss = 0;
+			if (task == 0) {
+				p = std::min(max_target, p);
+				p = std::max(min_target, p);
+				grad_loss = 2 * (p - target);
+			} else if (task == 1) {
+				grad_loss = target * ( (1.0/(1.0+exp(-target*p))) -  1.0);
+			}
+
+			if (fm->k1) {
+				lambda_w_grad.init(0.0);
+				for (uint i = 0; i < x.size; i++) {
+					uint g = meta->attr_group(x.data[i].id);
+					lambda_w_grad(g) += x.data[i].value * fm->w(x.data[i].id);
+				}
+				for (uint g = 0; g < meta->num_attr_groups; g++) {
+					lambda_w_grad(g) = -2 * learn_rate * lambda_w_grad(g);
+					reg_w(g) -= learn_rate * grad_loss * lambda_w_grad(g);
+					reg_w(g) = std::max(0.0, reg_w(g));
+				}
+			}
+			for (int f = 0; f < fm->num_factor; f++) {
+				// grad_lambdafg = (grad l(y(x),y)) * (-2 * alpha * (\sum_{l} x_l * v'_lf) * (\sum_{l \in group(g)} x_l * v_lf) - \sum_{l \in group(g)} x^2_l * v_lf * v'_lf)
+				// sum_f_dash      := \sum_{l} x_l * v'_lf, this is independent of the groups
+				// sum_f(g)        := \sum_{l \in group(g)} x_l * v_lf
+				// sum_f_dash_f(g) := \sum_{l \in group(g)} x^2_l * v_lf * v'_lf
+				double sum_f_dash = 0.0;
+				sum_f.init(0.0);
+				sum_f_dash_f.init(0.0);
+				for (uint i = 0; i < x.size; i++) {
+					// v_if' =  [ v_if * (1-alpha*lambda_v_f) - alpha * grad_v_if]
+					uint g = meta->attr_group(x.data[i].id);
+					double& v = fm->v(f,x.data[i].id);
+					double v_dash = v - learn_rate * (grad_v(f,x.data[i].id) + 2 * reg_v(g,f) * v);
+
+					sum_f_dash += v_dash * x.data[i].value;
+					sum_f(g) += v * x.data[i].value;
+					sum_f_dash_f(g) += v_dash * x.data[i].value * v * x.data[i].value;
+				}
+				for (uint g = 0; g < meta->num_attr_groups; g++) {
+					double lambda_v_grad = -2 * learn_rate *  (sum_f_dash * sum_f(g) - sum_f_dash_f(g));
+					reg_v(g,f) -= learn_rate * grad_loss * lambda_v_grad;
+					reg_v(g,f) = std::max(0.0, reg_v(g,f));
+				}
+			}
+
+		}
+
+		void update_means() {
+			mean_w = 0;
+			mean_v.init(0);
+			var_w = 0;
+			var_v.init(0);
+			for (uint j = 0; j < fm->num_attribute; j++) {
+				mean_w += fm->w(j);
+				var_w += fm->w(j)*fm->w(j);
+				for (int f = 0; f < fm->num_factor; f++) {
+					mean_v(f) += fm->v(f,j);
+					var_v(f) += fm->v(f,j)*fm->v(f,j);
+				}
+			}
+			mean_w /= (double) fm->num_attribute;
+			var_w = var_w/fm->num_attribute - mean_w*mean_w;
+			for (int f = 0; f < fm->num_factor; f++) {
+				mean_v(f) /= fm->num_attribute;
+				var_v(f) = var_v(f)/fm->num_attribute - mean_v(f)*mean_v(f);
+			}
+
+			mean_w = 0;
+			for (int f = 0; f < fm->num_factor; f++) {
+				mean_v(f) = 0;
+			}
+		}
+
+		virtual void learn(Data& train, Data& test, Data& validation) {
+			fm_learn_sgd::learn(train, test, validation);
+
+			std::cout << "Training using self-adaptive-regularization SGD."<< std::endl << "DON'T FORGET TO SHUFFLE THE ROWS IN TRAINING AND VALIDATION DATA TO GET THE BEST RESULTS." << std::endl;
+
+			// make sure that fm-parameters are initialized correctly (no other side effects)
+			fm->w.init(0);
+			fm->reg0 = 0;
+			fm->regw = 0;
+			fm->regv = 0;
+
+			// start with no regularization
+			reg_w.init(0.0);
+			reg_v.init(0.0);
+
+			std::cout << "Using " << train.data->getNumRows() << " rows for training model parameters and " << validation.data->getNumRows() << " for training shrinkage." << std::endl;
+
+			// SGD
+			for (int i = 0; i < num_iter; i++) {
+				double iteration_time = getusertime();
+
+				// SGD-based learning: both lambda and theta are learned
+				update_means();
+				validation.data->begin();
+				for (train.data->begin(); !train.data->end(); train.data->next()) {
+					sgd_theta_step(train.data->getRow(), train.target(train.data->getRowIndex()));
+
+					if (i > 0) { // make no lambda steps in the first iteration, because some of the gradients (grad_theta) might not be initialized.
+						if (validation.data->end()) {
+							update_means();
+							validation.data->begin();
+						}
+						sgd_lambda_step(validation.data->getRow(), validation.target(validation.data->getRowIndex()));
+						validation.data->next();
+					}
+				}
+
+
+				// (3) Evaluation
+				iteration_time = (getusertime() - iteration_time);
+				double metric_train = evaluate(train,optimize_metric);
+				double metric_test = evaluate(test,optimize_metric);
+				double metric_val = evaluate(validation,optimize_metric);
+
+				std::cout << "#Iter=" << std::setw(3) << i << "\tTrain=" << metric_train << "\tTest=" << metric_test  << "\tValidation"<< metric_val << std::endl;
+				if (log != NULL) {
+					log->log("wmean", mean_w);
+					log->log("wvar", var_w);
+					for (int f = 0; f < fm->num_factor; f++) {
+						{
+							std::ostringstream ss;
+							ss << "vmean" << f;
+							log->log(ss.str(), mean_v(f));
+						}
+						{
+							std::ostringstream ss;
+							ss << "vvar" << f;
+							log->log(ss.str(), var_v(f));
+						}
+					}
+					for (uint g = 0; g < meta->num_attr_groups; g++) {
+						{
+							std::ostringstream ss;
+							ss << "regw[" << g << "]";
+							log->log(ss.str(), reg_w(g));
+						}
+						for (int f = 0; f < fm->num_factor; f++) {
+							{
+								std::ostringstream ss;
+								ss << "regv[" << g << "," << f << "]";
+								log->log(ss.str(), reg_v(g,f));
+							}
+						}
+					}
+					log->log("time_learn", iteration_time);
+					log->log("optimize_metric_train", metric_train);
+					log->log("optimize_metric_val", metric_val);
+					log->newLine();
+				}
+			}
+		}
+
+		void debug() {
+			std::cout << "method=sgda" << std::endl;
+			fm_learn_sgd::debug();
+		}
+
+
+};
+
+#endif /*FM_LEARN_SGD_ELEMENT_ADAPT_REG_H_*/


### PR DESCRIPTION
1. Extended early stop updates learning rate (divide by 2) after each early stop activation, however stops this process if learn rate reaches lower than 1e-6.

2. Intermediate predictions saving at any desired iteration.

3. SGDA.

4. AUC evaluate per iteration. If early stop is used, validation auc can be maximised. Earlier validation log loss was minimized. Now have 2 options.

5. Makefile in src is updated (std c++) to support lambda expressions in ranking function for auc computation.